### PR TITLE
feat(postgres): allow users to configure postgres to read from S3

### DIFF
--- a/rootfs/docker-entrypoint-initdb.d/001_setup_envdir.sh
+++ b/rootfs/docker-entrypoint-initdb.d/001_setup_envdir.sh
@@ -9,10 +9,13 @@ AWS_SECRET_ACCESS_KEY=$(cat access-secret-key)
 # setup envvars for wal-e
 cp access-key-id AWS_ACCESS_KEY_ID
 cp access-secret-key AWS_SECRET_ACCESS_KEY
-echo "http://$DEIS_MINIO_SERVICE_HOST:$DEIS_MINIO_SERVICE_PORT" > WALE_S3_ENDPOINT
 echo "s3://$BUCKET_NAME" > WALE_S3_PREFIX
 if [ "$S3_URL" == "" ]; then
   echo "http://$DEIS_MINIO_SERVICE_HOST:$DEIS_MINIO_SERVICE_PORT" > S3_URL
+  echo "http://$DEIS_MINIO_SERVICE_HOST:$DEIS_MINIO_SERVICE_PORT" > WALE_S3_ENDPOINT
+else
+  # just need to set up WALE_S3_ENDPOINT because S3_URL already exists in the environment
+  echo "$S3_URL" > WALE_S3_ENDPOINT
 fi
 
 

--- a/rootfs/docker-entrypoint-initdb.d/001_setup_envdir.sh
+++ b/rootfs/docker-entrypoint-initdb.d/001_setup_envdir.sh
@@ -3,8 +3,12 @@
 cd "$WALE_ENVDIR"
 
 # access-key-id and access-secret-key files are mounted in via kubernetes secrets
-AWS_ACCESS_KEY_ID=$(cat access-key-id)
-AWS_SECRET_ACCESS_KEY=$(cat access-secret-key)
+if [ "$AWS_ACCESS_KEY_ID" == "" ]; then
+  AWS_ACCESS_KEY_ID=$(cat access-key-id)
+fi
+if [ "$AWS_SECRET_ACCESS_KEY" == "" ]; then
+  AWS_SECRET_ACCESS_KEY=$(cat access-secret-key)
+fi
 
 # setup envvars for wal-e
 cp access-key-id AWS_ACCESS_KEY_ID
@@ -31,9 +35,13 @@ EOF
 # HACK (bacongobbler): minio *must* use us-east-1 and signature version 4
 # for authentication.
 # see https://github.com/minio/minio#how-to-use-aws-cli-with-minio
+if [ "$AWS_DEFAULT_REGION" == "" ]; then
+  AWS_DEFAULT_REGION="us-east-1"
+fi
+
 cat << EOF > /root/.aws/config
 [default]
-region = us-east-1
+region = $AWS_DEFAULT_REGION
 s3 =
     signature_version = s3v4
 EOF

--- a/rootfs/docker-entrypoint.sh
+++ b/rootfs/docker-entrypoint.sh
@@ -10,8 +10,13 @@ set_listen_addresses() {
 	sed -ri "s/^#?(listen_addresses\s*=\s*)\S+/\1'$sedEscapedValue'/" "$PGDATA/postgresql.conf"
 }
 
-POSTGRES_USER="$(cat /var/run/secrets/deis/database/creds/user)"
-POSTGRES_PASSWORD="$(cat /var/run/secrets/deis/database/creds/password)"
+if [ "$POSTGRES_USER" == "" ]; then
+  POSTGRES_USER="$(cat /var/run/secrets/deis/database/creds/user)"
+fi
+
+if [ "$POSTGRES_PASSWORD" == "" ]; then
+  POSTGRES_PASSWORD="$(cat /var/run/secrets/deis/database/creds/password)"
+fi
 
 if [ "$1" = 'postgres' ]; then
 	mkdir -p "$PGDATA"


### PR DESCRIPTION
If a user wishes to set up an external S3 storage endpoint, they can overwrite the following environment variables:
- AWS_ACCESS_KEY_ID
- AWS_SECRET_ACCESS_KEY
- AWS_DEFAULT_REGION
- S3_URL (something like `https://s3-us-west-1.amazonaws.com`)

TESTING:
- build this image, modify deis-database-rc.yaml to point to this image
- modify deis-database-rc.yaml, injecting the following environment variables:

```
env:
  - name: AWS_ACCESS_KEY_ID
    value: "myaccesskey"
  - name: AWS_SECRET_ACCESS_KEY
    value: "mysecretkey"
  - name: S3_URL
    value: "https://s3-us-west-1.amazonaws.com"
  - name: AWS_DEFAULT_REGION
    value: "us-west-1"
```

install Deis, and observe that a `db_wal` bucket was created in your S3 region with database backups.

closes #33
