### PR TITLE
fix(docker-entrypoint-initdb): bump wait timeout

### DIFF
--- a/rootfs/docker-entrypoint-initdb.d/003_restore_from_backup.sh
+++ b/rootfs/docker-entrypoint-initdb.d/003_restore_from_backup.sh
@@ -46,6 +46,7 @@ EOF
   echo "restore_command = 'envdir /etc/wal-e.d/env wal-e wal-fetch \"%f\" \"%p\"'" >> "$PGDATA/recovery.conf"
   gosu postgres pg_ctl -D "$PGDATA" \
       -o "-c listen_addresses=''" \
+      -t 1200 \
       -w start
 else
   echo "No backups found. Performing an initial backup..."


### PR DESCRIPTION
The default wait time is 1 minute, which usually isn't enough time
for a recovery to finish. Bumping to 20 minutes seems to alleviate
the problem. We're not entirely sure why.

closes #56
