### PR TITLE
feat(create_bucket): raise client error if status code != 404

### DIFF
--- a/rootfs/bin/create_bucket
+++ b/rootfs/bin/create_bucket
@@ -25,6 +25,8 @@ except botocore.exceptions.ClientError as e:
     error_code = int(e.response['Error']['Code'])
     if error_code == 404:
         exists = False
+    else:
+        raise
 
 if not exists:
 	conn.create_bucket(Bucket=bucket_name)


### PR DESCRIPTION
When a client error occurs that differs from 404 (bucket exists),
we need to raise that error so the user knows what occurred.
