### PR TITLE
fix(rootfs): use https if port == 443

### DIFF
--- a/rootfs/docker-entrypoint-initdb.d/001_setup_envdir.sh
+++ b/rootfs/docker-entrypoint-initdb.d/001_setup_envdir.sh
@@ -20,6 +20,8 @@ else
     # If you add port 80 to the end of the endpoint_url, boto3 freaks out.
     # God I hate boto3 some days.
     echo "http://$DEIS_MINIO_SERVICE_HOST" > S3_URL
+  elif [ "$DEIS_MINIO_SERVICE_PORT" == "443" ]; then
+    echo "https://$DEIS_MINIO_SERVICE_HOST" > S3_URL
   else
     echo "http://$DEIS_MINIO_SERVICE_HOST:$DEIS_MINIO_SERVICE_PORT" > S3_URL
   fi


### PR DESCRIPTION
following the documentation from https://github.com/deis/workflow/blob/master/src/installing-workflow/configuring-object-storage.md#google-cloud-storage-interoperability-mode, if the port number in DEIS_MINIO_SERVICE_PORT == 443, the configured S3_URL will end up as `http://storage.googleapis.com:443`, which defeats the purpose.

addresses some of the concerns in #75.
