### PR TITLE
fix(rootfs): bump PG_VERSION to 9.4.7

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -21,7 +21,7 @@ ENV LANG en_US.utf8
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8
 
 ENV PG_MAJOR 9.4
-ENV PG_VERSION 9.4.6-1.pgdg80+1
+ENV PG_VERSION 9.4.7-1.pgdg80+1
 
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list
 


### PR DESCRIPTION
postgres is failing to deploy in CI because 9.4.6-1.pgdg80+1 no longer exists. Bumping to 9.4.7 following Docker's suit fixes this.
