### PR TITLE
tests(Makefile): add test-style shellcheck target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,15 @@ IMAGE_PREFIX ?= deis
 
 include versioning.mk
 
+SHELL_SCRIPTS = $(wildcard _scripts/*.sh) rootfs/bin/backup rootfs/bin/is_running
+
+# The following variables describe the containerized development environment
+# and other build options
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.11.0
+DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
+DEV_ENV_CMD := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
+DEV_ENV_CMD_INT := docker run -it --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
+
 all: docker-build docker-push
 
 # For cases where we're building from local
@@ -16,7 +25,15 @@ docker-build:
 	docker build --rm -t ${IMAGE} rootfs
 	docker tag -f ${IMAGE} ${MUTABLE_IMAGE}
 
-test:
+test: test-style test-unit test-functional
+
+test-style:
+	${DEV_ENV_CMD} shellcheck $(SHELL_SCRIPTS)
+
+test-unit:
+	@echo "Implement functional tests in _tests directory"
+
+test-functional:
 	contrib/ci/test.sh ${IMAGE}
 
 .PHONY: all docker-build docker-push test


### PR DESCRIPTION
Improves the testing safety net by linting `bash` scripts with `shellcheck` 0.4.3.

~~This passed in [the relevant CI job](https://travis-ci.org/deis/postgres/builds/122690181).~~ Refactored to use docker-go-dev's `shellcheck`.
