### PR TITLE
ref(.travis.yml): specify a bash project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
-sudo: required
-language: go
-go:
-  - 1.5.1
+language: bash
 branches:
   only:
     - master
+sudo: required
 services:
   - docker
 env:


### PR DESCRIPTION
"bash" is a closer match than "go" from Travis CI's point of view.
