### PR TITLE
fix(rootfs): create new recovery baseline after restore

### DIFF
--- a/rootfs/docker-entrypoint-initdb.d/003_restore_from_backup.sh
+++ b/rootfs/docker-entrypoint-initdb.d/003_restore_from_backup.sh
@@ -48,10 +48,10 @@ EOF
       -o "-c listen_addresses=''" \
       -t 1200 \
       -w start
-else
-  echo "No backups found. Performing an initial backup..."
-  gosu postgres envdir "$WALE_ENVDIR" wal-e backup-push "$PGDATA"
 fi
+
+echo "Performing an initial backup..."
+gosu postgres envdir "$WALE_ENVDIR" wal-e backup-push "$PGDATA"
 
 # ensure $PGDATA has the right permissions
 chown -R postgres:postgres "$PGDATA"


### PR DESCRIPTION
When you complete a recovery of the database for the first time, a new log timeline
is started with an ID of 2. When you restore again (timeline of 3), the timeline used when the last
backup occurred will be replayed. Because of this, if you restored the database and
did not perform a backup, all data committed after that successful recovery will be lost because
only WAL logs from the first timeline (the timeline that the database was last backed
up) will be restored.

In order to fix this, after completing a database recovery we create a fresh backup
in order to establish a new recovery baseline. That way we can now replay from
timeline 2.

STEPS TO TEST:
1. deploy a workflow cluster with this version of postgres
2. `deis create` a few apps
3. "delete" (via `kubectl delete po`) the database to force a restart
4. repeat steps 2 and 3
5. observe that all applications are present, and not just the first few created.

closes #94
