### PR TITLE
fix(contrib): assert 5 or 6 backups as acceptable

### DIFF
--- a/contrib/ci/test.sh
+++ b/contrib/ci/test.sh
@@ -77,8 +77,10 @@ docker exec $PG_JOB is_running
 puts-step "checking if minio has 5 backups"
 BACKUPS="$(docker exec $MINIO_JOB ls /home/minio/dbwal/basebackups_005/ | grep json)"
 NUM_BACKUPS="$(docker exec $MINIO_JOB ls /home/minio/dbwal/basebackups_005/ | grep -c json)"
-if [[ ! "$NUM_BACKUPS" -eq "5" ]]; then
-  puts-error "did not find 5 base backups, which is the default (found $NUM_BACKUPS)"
+# NOTE (bacongobbler): the BACKUP_FREQUENCY is only 1 second, so we could technically be checking
+# in the middle of a backup. Instead of failing, let's consider N+1 backups an acceptable case
+if [[ ! "$NUM_BACKUPS" -eq "5" && ! "$NUM_BACKUPS" -eq "6" ]]; then
+  puts-error "did not find 5 or 6 base backups. 5 is the default, but 6 may exist if a backup is currently in progress (found $NUM_BACKUPS)"
   puts-error "$BACKUPS"
   exit 1
 fi


### PR DESCRIPTION
If we're checking how many backups are available in the middle of a backup,
we may end up with N + 1 backups because the old one has not yet been deleted.
This is a quick and dirty fix to make the issue occur less often, however the
integration tests should be smart enough to determine if a backup is occurring
before checking the number of backups available.

addresses #67
