### PR TITLE
fix(rootfs): refactor database init process

### DIFF
--- a/rootfs/bin/backup
+++ b/rootfs/bin/backup
@@ -3,6 +3,8 @@
 export BACKUP_FREQUENCY=${BACKUP_FREQUENCY:-12h}
 export BACKUPS_TO_RETAIN=${BACKUPS_TO_RETAIN:-5}
 
+until is_running; do sleep 1; done
+
 while true; do
     sleep "$BACKUP_FREQUENCY"
     echo "Performing a base backup..."

--- a/rootfs/bin/backup-initial
+++ b/rootfs/bin/backup-initial
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+until is_running; do sleep 1; done
+
+while true; do
+    if [[ ! -f "$PGDATA/recovery.conf" ]] ; then
+        # Push a fresh backup so we have a new recovery baseline
+        echo "Performing an initial backup..."
+        envdir "$WALE_ENVDIR" wal-e backup-push "$PGDATA"
+        echo "Backup has been completed."
+        break
+    fi
+    sleep 1
+done

--- a/rootfs/bin/is_running
+++ b/rootfs/bin/is_running
@@ -8,4 +8,4 @@ if [[ -f "$PGDATA/recovery.conf" ]]; then
   exit 1
 fi
 
-gosu postgres pg_ctl status
+gosu postgres psql -l -t >/dev/null 2>&1

--- a/rootfs/docker-entrypoint-initdb.d/004_run_backups.sh
+++ b/rootfs/docker-entrypoint-initdb.d/004_run_backups.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 
+# Create a fresh backup as a starting point
+gosu postgres backup-initial &
+
 # Run periodic backups in the background
 gosu postgres backup &

--- a/rootfs/docker-entrypoint.sh
+++ b/rootfs/docker-entrypoint.sh
@@ -80,21 +80,17 @@ if [ "$1" = 'postgres' ]; then
 		EOSQL
 		echo
 
+		gosu postgres pg_ctl -D "$PGDATA" -m fast -w stop
+
 		echo
 		for f in /docker-entrypoint-initdb.d/*; do
 			case "$f" in
 				*.sh)  echo "$0: running $f"; . "$f" ;;
-				*.sql)
-					echo "$0: running $f";
-					psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" < "$f"
-					echo
-					;;
 				*)     echo "$0: ignoring $f" ;;
 			esac
 			echo
 		done
 
-		gosu postgres pg_ctl -D "$PGDATA" -m fast -w stop
 		set_listen_addresses '*'
 
 		echo


### PR DESCRIPTION
This refactor includes:
- removing PGCTLTIMEOUT, now you'll only need to modify the readinessProbe timeout
- cleaning up database boot script

Note that this is not required for 2.0.

Manual testing procedure:
- boot up database
- create a few apps
- delete the database via `kubectl delete po`
- ensure the database recovers correctly

closes #55
closes #108
