### PR TITLE
ref(Dockerfile): remove WORKFLOW_RELEASE envvar

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -59,5 +59,3 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364
 
 CMD ["/docker-entrypoint.sh", "postgres"]
 EXPOSE 5432
-
-ENV WORKFLOW_RELEASE 2.0.0


### PR DESCRIPTION
This is no longer necessary.

refs deis/workflow#356
