### PR TITLE
fix(rootfs): check if recovery.conf is present

### DIFF
--- a/rootfs/bin/is_running
+++ b/rootfs/bin/is_running
@@ -3,5 +3,9 @@
 # fail fast
 set -e
 
-# check if database is running
+if [[ -f "$PGDATA/recovery.conf" ]]; then
+  # postgres is in recovery mode, so we know it's not ready to accept incoming connections.
+  exit 1
+fi
+
 gosu postgres pg_ctl status


### PR DESCRIPTION
This allows is_running to fail when the database is in recovery mode.

closes #55
