### PR TITLE
fix(Makefile): disable swift tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ test-style:
 test-unit:
 	@echo "Implement functional tests in _tests directory"
 
-test-functional: test-functional-swift test-functional-minio
+test-functional: test-functional-minio
 
 test-functional-minio:
 	contrib/ci/test-minio.sh ${IMAGE}


### PR DESCRIPTION
This is blocking all PRs from going green at the moment because the image does not exist.

See https://travis-ci.org/deis/postgres/builds/147823089 for an example.
