### PR TITLE
ref(Dockerfile): move Dockerfile to root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364
 	&& apt-get clean \
 	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man /usr/share/doc
 
-COPY . /
+COPY rootfs /
 ENV WALE_ENVDIR=/etc/wal-e.d/env
 RUN mkdir -p $WALE_ENVDIR
 

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ all: docker-build docker-push
 # For cases where we're building from local
 # We also alter the RC file to set the image name.
 docker-build:
-	docker build --rm -t ${IMAGE} rootfs
+	docker build --rm -t ${IMAGE} .
 	docker tag ${IMAGE} ${MUTABLE_IMAGE}
 
 test: test-style test-unit test-functional


### PR DESCRIPTION
This allows deis/postgres to be deployed to Workflow through `git push deis master` (even if it doesn't work right now).

related to #135 
