### PR TITLE
fix(Dockerfile): pin working google-gax lib version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364
 	&& chown -R postgres /var/run/postgresql \
 	&& curl -sSL https://raw.githubusercontent.com/pypa/pip/7.1.2/contrib/get-pip.py | python - \
 	&& pip install --disable-pip-version-check --no-cache-dir git+https://github.com/deis/wal-e.git@380821a6c4ea4f98a244680d7c6c5b04b8c694b3 \
+	&& pip install --disable-pip-version-check --no-cache-dir google-gax===0.12.5 \
 	&& pip install --disable-pip-version-check --no-cache-dir envdir \
 	&& apt-get remove -y --auto-remove --purge \
 		gcc \


### PR DESCRIPTION
`make test` is currently broken on master due to a runtime Python requirements error:

``` python
pkg_resources.ContextualVersionConflict: (google-gax 0.13.0 (/usr/local/lib/python2.7/dist-packages),
Requirement.parse('google-gax<0.13.0,>=0.12.5'), set(['gax-google-logging-v2', 'gax-google-pubsub-v1']))
```

This installs `google-gax==0.12.5` explicitly, which should work around the error until we can upgrade to the wal-e 1.0 release...coming Real Soon Now.

See also deis/wal-e#17.
