### PR TITLE
chore(Dockerfile): consolidate a few chmod and chown into one layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,44 +15,50 @@ RUN adduser --system \
 	--group \
 	postgres
 
-RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
-	&& curl -L -o /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture)" \
-	&& curl -L -o /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/1.2/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu \
-	&& localedef -i en_US -c -f UTF-8 -A /etc/locale.alias en_US.UTF-8 \
-	&& apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 \
-	&& echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list \
-	&& apt-get update \
-	&& export DEBIAN_FRONTEND=noninteractive \
-	&& apt-get install -y postgresql-common util-linux \
-	&& sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf \
-	&& apt-get install -y --no-install-recommends \
-		gcc \
-		git \
-		libssl-dev \
-		libffi-dev \
-		lzop \
-		postgresql-$PG_MAJOR=$PG_VERSION \
-		postgresql-contrib-$PG_MAJOR=$PG_VERSION \
-		pv \
-		python \
-		python-dev \
-	&& mkdir -p /var/run/postgresql \
-	&& chown -R postgres /var/run/postgresql \
-	&& curl -sSL https://raw.githubusercontent.com/pypa/pip/7.1.2/contrib/get-pip.py | python - \
-	&& pip install --disable-pip-version-check --no-cache-dir git+https://github.com/deis/wal-e.git@380821a6c4ea4f98a244680d7c6c5b04b8c694b3 \
-	&& pip install --disable-pip-version-check --no-cache-dir google-gax===0.12.5 \
-	&& pip install --disable-pip-version-check --no-cache-dir envdir \
-	&& apt-get remove -y --auto-remove --purge \
-		gcc \
-		git \
-		libssl-dev \
-		libffi-dev \
-		python-dev \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/man /usr/share/doc
+RUN buildDeps='gcc git libffi-dev libssl-dev python-dev python-pip python-setuptools python-wheel'; \
+    localedef -i en_US -c -f UTF-8 -A /etc/locale.alias en_US.UTF-8 && \
+    export DEBIAN_FRONTEND=noninteractive && \
+	apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 && \
+	echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+        $buildDeps \
+        gosu \
+        lzop \
+        postgresql-$PG_MAJOR=$PG_VERSION \
+        postgresql-contrib-$PG_MAJOR=$PG_VERSION \
+        pv \
+        python \
+        postgresql-common \
+        util-linux \
+        # swift package needs pkg_resources
+        python-pkg-resources && \
+	mkdir -p /var/run/postgresql && \
+	chown -R postgres /var/run/postgresql && \
+	pip install --disable-pip-version-check --no-cache-dir git+https://github.com/deis/wal-e.git@380821a6c4ea4f98a244680d7c6c5b04b8c694b3 \
+                                                           google-gax===0.12.5 \
+                                                           envdir && \
+    # cleanup
+    apt-get purge -y --auto-remove $buildDeps && \
+    apt-get autoremove -y && \
+    apt-get clean -y && \
+    # package up license files if any by appending to existing tar
+    COPYRIGHT_TAR='/usr/share/copyrights.tar'; \
+    gunzip $COPYRIGHT_TAR.gz; tar -rf $COPYRIGHT_TAR /usr/share/doc/*/copyright; gzip $COPYRIGHT_TAR && \
+    rm -rf \
+        /usr/share/doc \
+        /usr/share/man \
+        /usr/share/info \
+        /usr/share/locale \
+        /var/lib/apt/lists/* \
+        /var/log/* \
+        /var/cache/debconf/* \
+        /etc/systemd \
+        /lib/lsb \
+        /lib/udev \
+        /usr/lib/x86_64-linux-gnu/gconv/IBM* \
+        /usr/lib/x86_64-linux-gnu/gconv/EBC* && \
+    bash -c "mkdir -p /usr/share/man/man{1..8}"
 
 COPY rootfs /
 ENV WALE_ENVDIR=/etc/wal-e.d/env


### PR DESCRIPTION
Get gosu from Ubuntu (1.7 gosu) and combine pip installs into one step

It doesn't really matter much but compared to v2.2.2 image this commit is 25mb smaller (includes the latest v0.3.4 image bump)
