### PR TITLE
chore(Makefile): bump docker-go-dev to 0.19.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SHELL_SCRIPTS = $(wildcard _scripts/*.sh) rootfs/bin/backup rootfs/bin/is_runnin
 
 # The following variables describe the containerized development environment
 # and other build options
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.11.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.19.0
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_CMD := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
 DEV_ENV_CMD_INT := docker run -it --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}


### PR DESCRIPTION
closes #147
