### PR TITLE
fix(Dockerfile): convert tabs to spaces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,25 @@
 FROM quay.io/deis/base:v0.3.4
 
 ENV LANG=en_US.utf8 \
-	PG_MAJOR=9.4 \
-	PG_VERSION=9.4.9-1.pgdg80+1 \
-	PGDATA=/var/lib/postgresql/data
+    PG_MAJOR=9.4 \
+    PG_VERSION=9.4.9-1.pgdg80+1 \
+    PGDATA=/var/lib/postgresql/data
 
 # Set this separately from those above since it depends on one of them
 ENV PATH=/usr/lib/postgresql/$PG_MAJOR/bin:$PATH
 
 # Add postgres user and group
 RUN adduser --system \
-	--shell /bin/bash \
-	--disabled-password \
-	--group \
-	postgres
+    --shell /bin/bash \
+    --disabled-password \
+    --group \
+    postgres
 
 RUN buildDeps='gcc git libffi-dev libssl-dev python-dev python-pip python-wheel'; \
     localedef -i en_US -c -f UTF-8 -A /etc/locale.alias en_US.UTF-8 && \
     export DEBIAN_FRONTEND=noninteractive && \
-	apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 && \
-	echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list && \
+    apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8 && \
+    echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' $PG_MAJOR > /etc/apt/sources.list.d/pgdg.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         $buildDeps \
@@ -34,9 +34,9 @@ RUN buildDeps='gcc git libffi-dev libssl-dev python-dev python-pip python-wheel'
         # swift package needs pkg_resources and setuptools
         python-pkg-resources \
         python-setuptools && \
-	mkdir -p /run/postgresql && \
-	chown -R postgres /run/postgresql && \
-	pip install --disable-pip-version-check --no-cache-dir git+https://github.com/deis/wal-e.git@380821a6c4ea4f98a244680d7c6c5b04b8c694b3 \
+    mkdir -p /run/postgresql && \
+    chown -R postgres /run/postgresql && \
+    pip install --disable-pip-version-check --no-cache-dir git+https://github.com/deis/wal-e.git@380821a6c4ea4f98a244680d7c6c5b04b8c694b3 \
                                                            google-gax===0.12.5 \
                                                            envdir && \
     # cleanup


### PR DESCRIPTION
This commit converts all spacing to tabs and prefixes concatenated strings
with '&&' rather than suffixing the strings. This brings a more consistent
style to the Dockerfile.
