### PR TITLE
ref(rootfs): remove timeout to pg_ctl start

### DIFF
--- a/charts/database/templates/database-deployment.yaml
+++ b/charts/database/templates/database-deployment.yaml
@@ -39,6 +39,8 @@ spec:
           env:
             - name: DATABASE_STORAGE
               value: "{{.Values.global.storage}}"
+            - name: PGCTLTIMEOUT
+              value: "{{.Values.postgres.timeout}}"
           readinessProbe:
             exec:
               command:

--- a/charts/database/values.yaml
+++ b/charts/database/values.yaml
@@ -57,3 +57,4 @@ postgres:
   password: "database password"
   host: "database host"
   port: "database port"
+  timeout: "1200"

--- a/contrib/ci/test-minio.sh
+++ b/contrib/ci/test-minio.sh
@@ -41,7 +41,7 @@ trap 'kill-container $MINIO_JOB' INT TERM
 MINIO_JOB=$(docker run -dv $CURRENT_DIR/tmp/aws-admin:/var/run/secrets/deis/minio/admin -v $CURRENT_DIR/tmp/aws-user:/var/run/secrets/deis/minio/user -v $CURRENT_DIR/tmp/k8s:/var/run/secrets/kubernetes.io/serviceaccount quay.io/deisci/minio:canary boot server /home/minio/)
 
 # boot postgres, linking the minio container and setting DEIS_MINIO_SERVICE_HOST and DEIS_MINIO_SERVICE_PORT
-PG_CMD="docker run -d --link $MINIO_JOB:minio -e BACKUP_FREQUENCY=1s -e DATABASE_STORAGE=minio -e DEIS_MINIO_SERVICE_HOST=minio -e DEIS_MINIO_SERVICE_PORT=9000 -v $CURRENT_DIR/tmp/creds:/var/run/secrets/deis/database/creds -v $CURRENT_DIR/tmp/aws-user:/var/run/secrets/deis/objectstore/creds $1"
+PG_CMD="docker run -d --link $MINIO_JOB:minio -e PGCTLTIMEOUT=1200 -e BACKUP_FREQUENCY=1s -e DATABASE_STORAGE=minio -e DEIS_MINIO_SERVICE_HOST=minio -e DEIS_MINIO_SERVICE_PORT=9000 -v $CURRENT_DIR/tmp/creds:/var/run/secrets/deis/database/creds -v $CURRENT_DIR/tmp/aws-user:/var/run/secrets/deis/objectstore/creds $1"
 
 # kill containers when this script exits or errors out
 trap 'kill-container $PG_JOB' INT TERM

--- a/contrib/ci/test-swift.sh
+++ b/contrib/ci/test-swift.sh
@@ -38,6 +38,7 @@ SWIFT_JOB=$(docker run --name onlyone --hostname onlyone -d -p 12345:8080 --volu
 # postgres container command
 PG_CMD="docker run -d --link $SWIFT_JOB:swift -e BACKUP_FREQUENCY=3s \
          -e DATABASE_STORAGE=swift \
+         -e PGCTLTIMEOUT=1200 \
          -v $CURRENT_DIR/tmp/creds:/var/run/secrets/deis/database/creds \
          -v $CURRENT_DIR/tmp/swift:/var/run/secrets/deis/objectstore/creds \
          $1"

--- a/rootfs/docker-entrypoint-initdb.d/003_restore_from_backup.sh
+++ b/rootfs/docker-entrypoint-initdb.d/003_restore_from_backup.sh
@@ -52,7 +52,6 @@ EOF
   chmod 0700 "$PGDATA"
   gosu postgres pg_ctl -D "$PGDATA" \
       -o "-c listen_addresses=''" \
-      -t 1200 \
       -w start
 fi
 


### PR DESCRIPTION
This timeout is tunable through the PGCTLTIMEOUT environment variable or, if not set,
to 60 seconds. We can set this in the chart instead.

See https://www.postgresql.org/docs/9.4/static/app-pg-ctl.html
