### PR TITLE
fix(setup_envdir): remove AWS_REGION from WALE_S3_ENDPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ RUN buildDeps='gcc git libffi-dev libssl-dev python3-dev python3-pip python3-whe
         envdir==0.7 \
         wal-e[aws,azure,google,swift]==v1.0.1 && \
     # "upgrade" boto to 2.43.0 + the patch to fix minio connections
-    pip install --disable-pip-version-check --no-cache-dir --upgrade git+https://github.com/deis/boto@d5d32ec42c99e9ecd030f8a4873adcda0070153d && \
+    pip install --disable-pip-version-check --no-cache-dir --upgrade git+https://github.com/deis/boto@88c980e56d1053892eb940d43a15a68af4ebb5e6 && \
     # cleanup
     apt-get purge -y --auto-remove $buildDeps && \
     apt-get autoremove -y && \

--- a/contrib/ci/test-minio.sh
+++ b/contrib/ci/test-minio.sh
@@ -41,7 +41,7 @@ trap 'kill-container $MINIO_JOB' INT TERM
 MINIO_JOB=$(docker run -dv $CURRENT_DIR/tmp/aws-admin:/var/run/secrets/deis/minio/admin -v $CURRENT_DIR/tmp/aws-user:/var/run/secrets/deis/minio/user -v $CURRENT_DIR/tmp/k8s:/var/run/secrets/kubernetes.io/serviceaccount quay.io/deisci/minio:canary boot server /home/minio/)
 
 # boot postgres, linking the minio container and setting DEIS_MINIO_SERVICE_HOST and DEIS_MINIO_SERVICE_PORT
-PG_CMD="docker run -d --link $MINIO_JOB:minio --link $MINIO_JOB:s3-us-east-1.minio -e PGCTLTIMEOUT=1200 -e BACKUP_FREQUENCY=1s -e DATABASE_STORAGE=minio -e DEIS_MINIO_SERVICE_HOST=minio -e DEIS_MINIO_SERVICE_PORT=9000 -v $CURRENT_DIR/tmp/creds:/var/run/secrets/deis/database/creds -v $CURRENT_DIR/tmp/aws-user:/var/run/secrets/deis/objectstore/creds $1"
+PG_CMD="docker run -d --link $MINIO_JOB:minio -e PGCTLTIMEOUT=1200 -e BACKUP_FREQUENCY=1s -e DATABASE_STORAGE=minio -e DEIS_MINIO_SERVICE_HOST=minio -e DEIS_MINIO_SERVICE_PORT=9000 -v $CURRENT_DIR/tmp/creds:/var/run/secrets/deis/database/creds -v $CURRENT_DIR/tmp/aws-user:/var/run/secrets/deis/objectstore/creds $1"
 
 # kill containers when this script exits or errors out
 trap 'kill-container $PG_JOB' INT TERM

--- a/rootfs/docker-entrypoint-initdb.d/001_setup_envdir.sh
+++ b/rootfs/docker-entrypoint-initdb.d/001_setup_envdir.sh
@@ -12,7 +12,7 @@ if [[ "$DATABASE_STORAGE" == "s3" || "$DATABASE_STORAGE" == "minio" ]]; then
     AWS_REGION="us-east-1"
     BUCKET_NAME="dbwal"
     # these only need to be set if we're not accessing S3 (boto will figure this out)
-    echo "http+path://s3-$AWS_REGION.$DEIS_MINIO_SERVICE_HOST:$DEIS_MINIO_SERVICE_PORT" > WALE_S3_ENDPOINT
+    echo "http+path://$DEIS_MINIO_SERVICE_HOST:$DEIS_MINIO_SERVICE_PORT" > WALE_S3_ENDPOINT
     echo "$DEIS_MINIO_SERVICE_HOST" > S3_HOST
     echo "$DEIS_MINIO_SERVICE_PORT" > S3_PORT
     # enable sigv4 authentication


### PR DESCRIPTION
boto resolves this internally using AWS_REGION. The warning about AWS_REGION being ignored is for a small section of wal-e's code and is still passed onto boto.

This also includes a patch for boto that resolves an issue with their s3v4 auth handler where AWS_REGION is not respected.

fixes #160 