### PR TITLE
ref(backup): bump default base backup interval to 4h

### DIFF
--- a/rootfs/bin/backup
+++ b/rootfs/bin/backup
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export BACKUP_FREQUENCY=${BACKUP_FREQUENCY:-12h}
+export BACKUP_FREQUENCY=${BACKUP_FREQUENCY:-4h}
 export BACKUPS_TO_RETAIN=${BACKUPS_TO_RETAIN:-5}
 
 while true; do


### PR DESCRIPTION
This means that base backups will occur once every 4 hours rather than once
every 12 hours. This should speed up recovery times significantly with only a
minor bump on CPU usage every 4 hours.