### PR TITLE
fix(gcs): Use correct env variable for the gcs service account file path

### DIFF
--- a/rootfs/bin/create_bucket
+++ b/rootfs/bin/create_bucket
@@ -28,8 +28,8 @@ if os.getenv('DATABASE_STORAGE') == "s3":
 
 elif os.getenv('DATABASE_STORAGE') == "gcs":
     scopes = ['https://www.googleapis.com/auth/devstorage.full_control']
-    credentials = ServiceAccountCredentials.from_json_keyfile_name(os.getenv('GS_APPLICATION_CREDS'), scopes=scopes)
-    with open(os.getenv('GS_APPLICATION_CREDS')) as data_file:
+    credentials = ServiceAccountCredentials.from_json_keyfile_name(os.getenv('GOOGLE_APPLICATION_CREDENTIALS'), scopes=scopes)
+    with open(os.getenv('GOOGLE_APPLICATION_CREDENTIALS')) as data_file:
         data = json.load(data_file)
     conn = Client(credentials=credentials, project=data['project_id'])
     exists = True

--- a/rootfs/docker-entrypoint-initdb.d/001_setup_envdir.sh
+++ b/rootfs/docker-entrypoint-initdb.d/001_setup_envdir.sh
@@ -28,10 +28,10 @@ if [[ "$DATABASE_STORAGE" == "s3" || "$DATABASE_STORAGE" == "minio" ]]; then
   echo $AWS_REGION > AWS_REGION
   echo $BUCKET_NAME > BUCKET_NAME
 elif [ "$DATABASE_STORAGE" == "gcs" ]; then
-  GS_APPLICATION_CREDS="/var/run/secrets/deis/objectstore/creds/key.json"
+  GOOGLE_APPLICATION_CREDENTIALS="/var/run/secrets/deis/objectstore/creds/key.json"
   BUCKET_NAME=$(cat /var/run/secrets/deis/objectstore/creds/database-bucket)
   echo "gs://$BUCKET_NAME" > WALE_GS_PREFIX
-  echo $GS_APPLICATION_CREDS > GS_APPLICATION_CREDS
+  echo $GOOGLE_APPLICATION_CREDENTIALS > GOOGLE_APPLICATION_CREDENTIALS
   echo $BUCKET_NAME > BUCKET_NAME
 elif [ "$DATABASE_STORAGE" == "azure" ]; then
   WABS_ACCOUNT_NAME=$(cat /var/run/secrets/deis/objectstore/creds/accountname)


### PR DESCRIPTION
This got missed during our transition from our fork of wal-e to upstream.
https://github.com/deis/wal-e#google-storage