### PR TITLE
fix(setup-envdir): convert AWS_REGION to WALE_S3_ENDPOINT

### DIFF
--- a/rootfs/docker-entrypoint-initdb.d/001_setup_envdir.sh
+++ b/rootfs/docker-entrypoint-initdb.d/001_setup_envdir.sh
@@ -8,6 +8,15 @@ if [[ "$DATABASE_STORAGE" == "s3" || "$DATABASE_STORAGE" == "minio" ]]; then
   if [[ "$DATABASE_STORAGE" == "s3" ]]; then
     AWS_REGION=$(cat /var/run/secrets/deis/objectstore/creds/region)
     BUCKET_NAME=$(cat /var/run/secrets/deis/objectstore/creds/database-bucket)
+    # Convert $AWS_REGION into $WALE_S3_ENDPOINT to avoid "Connection reset by peer" from
+    # regions other than us-standard.
+    # See https://github.com/wal-e/wal-e/issues/167
+    # See https://github.com/boto/boto/issues/2207
+    if [[ "$AWS_REGION" == "us-east-1" ]]; then
+      echo "https+path://s3.amazonaws.com:443" > WALE_S3_ENDPOINT
+    else
+      echo "https+path://s3-${AWS_REGION}.amazonaws.com:443" > WALE_S3_ENDPOINT
+    fi
   else
     AWS_REGION="us-east-1"
     BUCKET_NAME="dbwal"


### PR DESCRIPTION
Converting $AWS_REGION into $WALE_S3_ENDPOINT avoids the
"Connection reset by peer" error when uploading files to buckets
creted in regions other than us-east-1.

See boto/boto#2207
See wal-e/wal-e#167