### PR TITLE
fix(create-bucket): fix S3ResponseError on bucket create

### DIFF
--- a/rootfs/bin/create_bucket
+++ b/rootfs/bin/create_bucket
@@ -2,7 +2,7 @@
 
 import os
 
-import boto.s3
+import boto
 import json
 import swiftclient
 from boto import config as botoconfig
@@ -22,7 +22,7 @@ bucket_name = os.getenv('BUCKET_NAME')
 region = os.getenv('AWS_REGION')
 
 if os.getenv('DATABASE_STORAGE') == "s3":
-    conn = boto.s3.connect_to_region(region)
+    conn = boto.connect_s3()
 
     if not bucket_exists(conn, bucket_name):
         conn.create_bucket(bucket_name, location=region)


### PR DESCRIPTION
It seems that if you connect to a specific region and call conn.lookup(),
it will return False and raise an S3ResponseError. However, if you connect
without specifying the region info, it will return True.

Related: https://github.com/boto/boto/issues/443