### PR TITLE
Revert "fix(boto): specify the region while getting s3 connection"

### DIFF
--- a/rootfs/bin/create_bucket
+++ b/rootfs/bin/create_bucket
@@ -2,7 +2,7 @@
 
 import os
 
-import boto.s3
+import boto
 import json
 import swiftclient
 from boto import config as botoconfig
@@ -19,13 +19,12 @@ def bucket_exists(conn, name):
     return True
 
 bucket_name = os.getenv('BUCKET_NAME')
-region = os.getenv('AWS_REGION')
 
 if os.getenv('DATABASE_STORAGE') == "s3":
-    conn = boto.s3.connect_to_region(region)
+    conn = boto.connect_s3()
 
     if not bucket_exists(conn, bucket_name):
-        conn.create_bucket(bucket_name, location=region)
+        conn.create_bucket(bucket_name)
 
 elif os.getenv('DATABASE_STORAGE') == "gcs":
     scopes = ['https://www.googleapis.com/auth/devstorage.full_control']

--- a/rootfs/docker-entrypoint-initdb.d/001_setup_envdir.sh
+++ b/rootfs/docker-entrypoint-initdb.d/001_setup_envdir.sh
@@ -25,6 +25,9 @@ if [[ "$DATABASE_STORAGE" == "s3" || "$DATABASE_STORAGE" == "minio" ]]; then
     echo $AWS_ACCESS_KEY_ID > AWS_ACCESS_KEY_ID
     echo $AWS_SECRET_ACCESS_KEY > AWS_SECRET_ACCESS_KEY
   fi
+  # HACK(bacongobbler): hardcode region to us-east-1 regardless of set region
+  # see https://github.com/deis/postgres/issues/173
+  AWS_REGION="us-east-1"
   echo $AWS_REGION > AWS_REGION
   echo $BUCKET_NAME > BUCKET_NAME
 elif [ "$DATABASE_STORAGE" == "gcs" ]; then

--- a/rootfs/docker-entrypoint-initdb.d/001_setup_envdir.sh
+++ b/rootfs/docker-entrypoint-initdb.d/001_setup_envdir.sh
@@ -8,15 +8,6 @@ if [[ "$DATABASE_STORAGE" == "s3" || "$DATABASE_STORAGE" == "minio" ]]; then
   if [[ "$DATABASE_STORAGE" == "s3" ]]; then
     AWS_REGION=$(cat /var/run/secrets/deis/objectstore/creds/region)
     BUCKET_NAME=$(cat /var/run/secrets/deis/objectstore/creds/database-bucket)
-    # Convert $AWS_REGION into $WALE_S3_ENDPOINT to avoid "Connection reset by peer" from
-    # regions other than us-standard.
-    # See https://github.com/wal-e/wal-e/issues/167
-    # See https://github.com/boto/boto/issues/2207
-    if [[ "$AWS_REGION" == "us-east-1" ]]; then
-      echo "https+path://s3.amazonaws.com:443" > WALE_S3_ENDPOINT
-    else
-      echo "https+path://s3-${AWS_REGION}.amazonaws.com:443" > WALE_S3_ENDPOINT
-    fi
   else
     AWS_REGION="us-east-1"
     BUCKET_NAME="dbwal"


### PR DESCRIPTION
This reverts commit 388c593dd182755fad2218ef2c1f24d39bc29948.

While it is the correct thing to do, it is a low severity issue and blocks users from upgrading to v2.9.0 due to #173. Reverting this commit returns the database to looking up and creating buckets in us-east-1. While it isn't optimal, it's not a security/billing issue.