### PR TITLE
fix(create_bucket): try default s3 region on create error

### DIFF
--- a/rootfs/bin/create_bucket
+++ b/rootfs/bin/create_bucket
@@ -6,6 +6,7 @@ import boto.s3
 import json
 import swiftclient
 from boto import config as botoconfig
+from boto.exception import S3CreateError
 from boto.s3.connection import S3Connection, OrdinaryCallingFormat
 from oauth2client.service_account import ServiceAccountCredentials
 from gcloud.storage.client import Client
@@ -23,9 +24,20 @@ region = os.getenv('AWS_REGION')
 
 if os.getenv('DATABASE_STORAGE') == "s3":
     conn = boto.s3.connect_to_region(region)
-
     if not bucket_exists(conn, bucket_name):
-        conn.create_bucket(bucket_name, location=region)
+        try:
+            conn.create_bucket(bucket_name, location=region)
+        except S3CreateError as err:
+            # try again in the default S3 region before giving up
+            default_region = 'us-east-1'
+            if region != default_region:
+                print('Failed to create bucket in {}, trying default region {}...'.format(
+                    region, default_region))
+                conn = boto.s3.connect_to_region(default_region)
+                if not bucket_exists(conn, bucket_name):
+                    conn.create_bucket(bucket_name, location=default_region)
+                # TODO: if we got here, somehow we need to propagate "us-east-1"
+                # into WALE_S3_ENDPOINT...
 
 elif os.getenv('DATABASE_STORAGE') == "gcs":
     scopes = ['https://www.googleapis.com/auth/devstorage.full_control']


### PR DESCRIPTION
Workflow v2.8.0 and earlier could mistakenly create the database S3 bucket in `us-east-1` regardless of what region was specified. That behavior is fixed now, but the fix could cause access problems when upgrading.

This retries in "us-east-1" on a bucket create error to be backward-bug-compatible with existing Workflow installations.