### PR TITLE
feat(charts): Add support to specify creds for in cluster db through values file

### DIFF
--- a/charts/database/templates/database-secret-creds.yaml
+++ b/charts/database/templates/database-secret-creds.yaml
@@ -8,8 +8,8 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install
 data: {{ if eq .Values.global.database_location "on-cluster"}}
-  user: {{ randAlphaNum 32 | b64enc }}
-  password: {{ randAlphaNum 32 | b64enc }}{{ else if eq .Values.global.database_location "off-cluster"}}
+  user: {{ if .Values.username | default "" | ne "" }}{{ .Values.username | b64enc }}{{ else }}{{ randAlphaNum 32 | b64enc }}{{ end }}
+  password: {{ if .Values.password | default "" | ne "" }}{{ .Values.password | b64enc }}{{ else }}{{ randAlphaNum 32 | b64enc }}{{ end }}{{ else if eq .Values.global.database_location "off-cluster"}}
   user: {{ .Values.postgres.username | b64enc }}
   password: {{ .Values.postgres.password | b64enc }}
   name: {{ .Values.postgres.name | b64enc }}

--- a/charts/database/values.yaml
+++ b/charts/database/values.yaml
@@ -3,6 +3,10 @@ pull_policy: "Always"
 docker_tag: canary
 # limits_cpu: "100m"
 # limits_memory: "50Mi"
+# The username and password to be used by the on-cluster database.
+# If left empty they will be generated using randAlphaNum
+username: ""
+password: ""
 
 postgres:
   name: "database name"


### PR DESCRIPTION
This will allows users to specify a different username password instead of we generating for them through values file instead of downloading the charts and modifying the manifests.