### PR TITLE
fix(postgres): block invalid S3 bucket name

### DIFF
--- a/rootfs/docker-entrypoint-initdb.d/001_setup_envdir.sh
+++ b/rootfs/docker-entrypoint-initdb.d/001_setup_envdir.sh
@@ -7,7 +7,7 @@ if [[ "$DATABASE_STORAGE" == "s3" || "$DATABASE_STORAGE" == "minio" ]]; then
   AWS_SECRET_ACCESS_KEY=$(cat /var/run/secrets/deis/objectstore/creds/secretkey)
   if [[ "$DATABASE_STORAGE" == "s3" ]]; then
     AWS_REGION=$(cat /var/run/secrets/deis/objectstore/creds/region)
-    BUCKET_NAME=$(cat /var/run/secrets/deis/objectstore/creds/database-bucket)
+    BUCKET_NAME=$(cat /var/run/secrets/deis/objectstore/creds/database-bucket | sed "s/[.]/-/g")
     # Convert $AWS_REGION into $WALE_S3_ENDPOINT to avoid "Connection reset by peer" from
     # regions other than us-standard.
     # See https://github.com/wal-e/wal-e/issues/167


### PR DESCRIPTION
Using a period in an S3 BUCKET_NAME causes `helm install -f values.yaml deis/workflow --namespace=deis` to fail.

REPRODUCING THE BUG

Using a period in BUCKET_NAME causes `helm install -f values.yaml deis/workflow --namespace=deis` to fail with this error:
```
ssl.CertificateError: hostname 'deis.subdomain.domain.com-registry.s3-us-west-2.amazonaws.com' doesn't match either of 's3-us-west-2.amazonaws.com', '*.s3-us-west-2.amazonaws.com', 's3.us-west-2.amazonaws.com', '*.s3.us-west-2.amazonaws.com', 's3.dualstack.us-west-2.amazonaws.com', '*.s3.dualstack.us-west-2.amazonaws.com', '*.s3.amazonaws.com'
2017/01/14 07:20:04 Error creating the registry bucket: exit status 1
```

A POSSIBLE FIX

Not sure how to create a test for this (I just started using Deis 4 days ago), but, a hacky test is this:
```
echo "a.bad.thing-mixed-with-a-good-thing" | sed "s/[.]/-/g"
```

RELATED ISSUES

https://github.com/deis/workflow/issues/700
https://github.com/deis/workflow/pull/701 (documentation fix)

Note: this bug also exists for https://github.com/deis/registry/blob/master/rootfs/bin/create-bucket#L27