### PR TITLE
feat(Makefile): set docker build flags via environment variable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ services:
 env:
   # HACK(bacongobbler): make travis tests work
   - DEIS_REGISTRY=travis-ci/
+  - DOCKER_BUILD_FLAGS="--pull --no-cache"
 install:
   - make docker-build
 script:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ all: docker-build docker-push
 # For cases where we're building from local
 # We also alter the RC file to set the image name.
 docker-build:
-	docker build --rm -t ${IMAGE} .
+	docker build ${DOCKER_BUILD_FLAGS} -t ${IMAGE} .
 	docker tag ${IMAGE} ${MUTABLE_IMAGE}
 
 test: test-style test-unit test-functional


### PR DESCRIPTION
This allows CI jobs to set the "--pull --no-cache" flags in particular. The "--rm" flag was removed since it's the default.

See deis/jenkins-jobs#327.