### PR TITLE
fix(create_bucket): avoid S3 InvalidLocationConstraint error

### DIFF
--- a/rootfs/bin/create_bucket
+++ b/rootfs/bin/create_bucket
@@ -26,7 +26,11 @@ if os.getenv('DATABASE_STORAGE') == "s3":
     conn = boto.s3.connect_to_region(region)
     if not bucket_exists(conn, bucket_name):
         try:
-            conn.create_bucket(bucket_name, location=region)
+            if region == "us-east-1":
+                # use "US Standard" region. workaround for https://github.com/boto/boto3/issues/125
+                conn.create_bucket(bucket_name)
+            else:
+                conn.create_bucket(bucket_name, location=region)
         # NOTE(bacongobbler): for versions prior to v2.9.0, the bucket is created in the default region.
         # if we got here, we need to propagate "us-east-1" into WALE_S3_ENDPOINT because the bucket
         # exists in a different region and we cannot find it.


### PR DESCRIPTION
calling create_bucket(bucket_name, region="us-east-1") yields the
following error:

```
boto.exception.S3ResponseError: S3ResponseError: 400 Bad Request
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>InvalidLocationConstraint</Code>
<Message>The specified location-constraint is not valid</Message>
<LocationConstraint>us-east-1</LocationConstraint>...</Error>
```

based on the comments in boto/boto3#125 this commit omits the region
kwarg to the create_bucket() call when `s3.region` is set to "us-east-1"