### PR TITLE
chore(Dockerfile): bump PG_VERSION to 9.4.11-1.pgdg16.04+1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/deis/base:v0.3.6
 
 ENV LANG=en_US.utf8 \
     PG_MAJOR=9.4 \
-    PG_VERSION=9.4.10-1.pgdg16.04+1 \
+    PG_VERSION=9.4.11-1.pgdg16.04+1 \
     PGDATA=/var/lib/postgresql/data
 
 # Set this separately from those above since it depends on one of them


### PR DESCRIPTION
The previously used PostgreSQL version (9.4.10-1.pgdg16.04+1) is no
longer in the repositories. Bumping to the latest patch release of 9.4