### PR TITLE
fix(.travis.yml): declare env vars on one line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ services:
   - docker
 env:
   # HACK(bacongobbler): make travis tests work
-  - DEIS_REGISTRY=travis-ci/
-  - DOCKER_BUILD_FLAGS="--pull --no-cache"
+  - DEIS_REGISTRY=travis-ci/ DOCKER_BUILD_FLAGS="--pull --no-cache"
 install:
   - make docker-build
 script:


### PR DESCRIPTION
I noticed two jobs were being run for each postgres PR in Travis CI. Without this change, Travis CI [expands the build matrix](https://docs.travis-ci.com/user/environment-variables/#Defining-Multiple-Variables-per-Item) and sets one environment variable per build, which was not intended.